### PR TITLE
rm deprecated & unused css

### DIFF
--- a/en/styles/website.css
+++ b/en/styles/website.css
@@ -216,12 +216,6 @@ img {
   margin: auto;
 }
 
-#page-footer img {
-  display: inline;
-  margin: 0;
-}
-
-
 /* Hide GitBook link (keep it white for they pagerank) */
 a.gitbook-link{
   color: white;

--- a/fr/styles/website.css
+++ b/fr/styles/website.css
@@ -193,12 +193,6 @@ img {
   margin: auto;
 }
 
-#page-footer img {
-  display: inline;
-  margin: 0;
-}
-
-
 /* Hide GitBook link (keep it white for they pagerank) */
 a.gitbook-link{
   color: white;


### PR DESCRIPTION
Hi, developer of gitbook-plugin-localized-footer here.

I deprecated a css selector in the plugin, and made changes to your css accordingly.
As your current footer does not contain any images, i deleted the selector entirely